### PR TITLE
set id of incoming subreddit and subject to match param

### DIFF
--- a/src/main/java/edu/ucsb/cs156/team02/controllers/CollegiateSubredditController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/CollegiateSubredditController.java
@@ -85,6 +85,7 @@ public class CollegiateSubredditController extends ApiController {
                 .body(String.format("Subreddit with id %d not found", id));
         }
         else{
+            incomingCsr.setId(id);
             collegiateSubredditRepository.save(incomingCsr);
             String body = mapper.writeValueAsString(incomingCsr);
             return ResponseEntity.ok().body(body);

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -109,7 +109,7 @@ public class UCSBSubjectController extends ApiController {
             .body(String.format("Subject with id %d not found", id)); 
         }
         else{
-            // incomingSubject.setId(id);
+            incomingSubject.setId(id);
             subjectRepository.save(incomingSubject);    
             String body = mapper.writeValueAsString(incomingSubject);
             return ResponseEntity.ok().body(body);


### PR DESCRIPTION
Before this change, when the incoming subject/subreddit's ID differed from the one passed in as a parameter, the wrong record in the database would get updated (or a new one would get made), I think.